### PR TITLE
Use mean duration rather than total duration

### DIFF
--- a/benches/std_server.rs
+++ b/benches/std_server.rs
@@ -76,6 +76,7 @@ fn start_clients(port: u16, connection_count: usize, iters: u64) -> Duration {
         .into_iter()
         .map(|h| h.join().unwrap())
         .sum::<Duration>()
+        / connection_count as u32
 }
 
 fn send_pings(port: u16, num_pings: u64) -> io::Result<Duration> {

--- a/benches/tokio_server.rs
+++ b/benches/tokio_server.rs
@@ -88,7 +88,7 @@ async fn start_clients(port: u16, connection_count: usize, iters: u64) -> Durati
     for handle in handles {
         total_duration += handle.await.unwrap();
     }
-    total_duration
+    total_duration / connection_count as u32
 }
 
 async fn send_pings(port: u16, num_pings: u64) -> io::Result<Duration> {


### PR DESCRIPTION
Divide by the number of connections to make the per-ping value directly comparable
